### PR TITLE
Fixes for instance creation

### DIFF
--- a/create_nodes.yaml
+++ b/create_nodes.yaml
@@ -21,7 +21,7 @@
       exact_count: "{{ instances }}"
       count_tag:
         Name: "{{ cluster_id }}"
-      wait: no
+      wait: true
       volumes:
         - volume_size: 10
           device_type: gp2
@@ -70,4 +70,4 @@
       type: A
       ttl: 300
       value: "{{ item.1.public_ip }}"
-    with_indexed_items: "{{ ec2.instances }}"
+    with_indexed_items: "{{ ec2.tagged_instances }}"

--- a/inventory/aws/hosts/ec2.ini
+++ b/inventory/aws/hosts/ec2.ini
@@ -136,7 +136,7 @@ group_by_elasticache_replication_group = True
 # a list separated by commas. See examples below.
 
 # Retrieve only instances with (key=value) env=staging tag
-instance_filters = tag:Name=gluster-demo
+#instance_filters = tag:Name=gluster-demo
 
 # Retrieve only instances with role=webservers OR role=dbservers tag
 # instance_filters = tag:role=webservers,tag:role=dbservers


### PR DESCRIPTION
1. Dynamic Inventory refresh occurred before public_ip assigned.
Change `wait` to `true` in `create_nodes`.  It was returning before a `public_ip` was assigned, and therefore null

2. DNS Entries created in subsequent runs have incorrect student sequence numbers.
When adding additional instances (e.g., `run.sh 5`, followed by `./run.sh 6`), the instances list contained only the *new* items.  So route53 updated the DNS record for student-0, rather than adding a record.  In create_route53 task, I changed the list from `instances` to `tagged_instances`, which contains all of the instances, rather than just the new one.  

3. Dynamic Inventory tag filter.
`ec2.ini` has an incorrect filter defined:
`instance_filters = tag:Name=gluster-demo`
I commented it out.