### PR TITLE
Update to latest RHEL AMI

### DIFF
--- a/create_nodes.yaml
+++ b/create_nodes.yaml
@@ -48,11 +48,10 @@
 #    debug: var=groups
 #    when: debug_print == true
 
-#  - name: Wait for SSH to come up
-#    wait_for: host={{ item }} port=22 delay=0 timeout=600 state=started
-#    with_items:
-#      - "{{ groups.ec2 }}"
-#
+  - name: Wait for SSH to come up
+    wait_for: host={{ item.public_dns_name }} port=22 delay=0 timeout=600 state=started
+    with_items: "{{ ec2.tagged_instances }}"
+ 
 #  - name: Wait for successful SSH
 #    command: "ssh -o StrictHostKeyChecking=no -o PasswordAuthentication=no -o ConnectTimeout=10 -o UserKnownHostsFile=/dev/null ec2-user@{{ item }} echo host is up"
 #    register: result
@@ -71,3 +70,15 @@
       ttl: 300
       value: "{{ item.1.public_ip }}"
     with_indexed_items: "{{ ec2.tagged_instances }}"
+
+  - name: Create /opt/rhel_data directory
+    command: "ssh -o StrictHostKeyChecking=no -o PasswordAuthentication=no -o ConnectTimeout=10 -o UserKnownHostsFile=/dev/null -t -t ec2-user@{{ item.public_dns_name }} sudo mkdir -p /opt/rhel_data"
+    with_items: "{{ ec2.tagged_instances }}"
+
+  - name: Enable Extras Repo
+    command: "ssh -o StrictHostKeyChecking=no -o PasswordAuthentication=no -o ConnectTimeout=10 -o UserKnownHostsFile=/dev/null -t -t ec2-user@{{ item.public_dns_name }} sudo yum-config-manager --enable rhui-REGION-rhel-server-extras"
+    with_items: "{{ ec2.tagged_instances }}"
+
+  - name: Install utilities
+    command: "ssh -o StrictHostKeyChecking=no -o PasswordAuthentication=no -o ConnectTimeout=10 -o UserKnownHostsFile=/dev/null -t -t ec2-user@{{ item.public_dns_name }} sudo yum -y install vim-enhanced"
+    with_items: "{{ ec2.tagged_instances }}"

--- a/vars.yaml
+++ b/vars.yaml
@@ -5,7 +5,7 @@ cluster_id: docker-workshop
 # Currently only supports us-east-1
 ec2_region: us-east-1
 ec2_az: c
-ec2_image: ami-6ac0bc00
+ec2_image: ami-10251c7a
 ec2_keypair: rhtps-docker-workshop
 ec2_instance_type: t2.medium
 r53_zone: rhtps.io


### PR DESCRIPTION
The AMI that we typically use for the workshop is missing.  This update changes the AMI ID to the current standard RHEL AMI, and adds configuration that we expect to be there for the workshop.  